### PR TITLE
Fix `transmission_delay` to be the intended value

### DIFF
--- a/postfixlog/postfixlog.go
+++ b/postfixlog/postfixlog.go
@@ -95,7 +95,7 @@ func (sb *StatsBin) Display(duration float64) {
 	sb.DisplayDelay(now, "recving", sb.receivingDelay)
 	sb.DisplayDelay(now, "queuing", sb.queuingDelay)
 	sb.DisplayDelay(now, "connection", sb.connectionDelay)
-	sb.DisplayDelay(now, "transmission", sb.connectionDelay)
+	sb.DisplayDelay(now, "transmission", sb.transmissionDelay)
 
 	if duration > 0 {
 		fmt.Printf("postfixlog.transfer_num.2xx_count\t%f\t%d\n", sb.c2xx/duration, now)


### PR DESCRIPTION
close #6 

## why

Wrong variable ( `sb.connectionDelay` ) used.

## what 

Using `sb.transmissionDelay` to print `transmission` value.

## operation check

Using the `testlog` file shown below, I confirmed that `postfixlog.transmission_delay.average` was `0.17` after the fix.

```
$ cat testlog 
Sep 11 19:24:51 relaymail1 postfix/smtp[7570]: 69FFFC00B6: to=<xxxxxxx@example.jp>, relay=x.x
.x.x[y.y.y.y]:25, delay=0.31, delays=0.04/0/0.09/0.17, dsn=2.0.0, status=sent (250 Ok)
```

### before

```
$ ./mackerel-plugin-postfix-log --logfile $(pwd)/testlog 2>/dev/null | grep average
postfixlog.total_delay.average  0.310000        1662892595
postfixlog.recving_delay.average        0.040000        1662892595
postfixlog.queuing_delay.average        0.000000        1662892595
postfixlog.connection_delay.average     0.090000        1662892595
postfixlog.transmission_delay.average   0.090000        1662892595
```

### after

```
$ ./mackerel-plugin-postfix-log --logfile $(pwd)/testlog 2>/dev/null | grep average
postfixlog.total_delay.average  0.310000        1662892619
postfixlog.recving_delay.average        0.040000        1662892619
postfixlog.queuing_delay.average        0.000000        1662892619
postfixlog.connection_delay.average     0.090000        1662892619
postfixlog.transmission_delay.average   0.170000        1662892619
```