### PR TITLE
Disabling cgo since the libc environment depends on the binary creation environment. 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CGO_ENABLED: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: test
         run: make check
+        env:
+          CGO_ENABLED: 0
 
       - name: Snapshot GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: arm64
+    env:
+      - CGO_ENABLED=0
 archives:
   - format: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
same: https://github.com/kazeburo/mackerel-plugin-axslog/pull/26